### PR TITLE
use_api_call

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.analysis.autoImportCompletions": true,
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/pybt2/runtime/analysis.py
+++ b/pybt2/runtime/analysis.py
@@ -1,12 +1,11 @@
 from abc import ABCMeta, abstractmethod
-from typing import Mapping, Optional, Type
+from typing import Any, Mapping, Optional, Type
 
 from attr import frozen
 from typing_extensions import override
 
 from pybt2.runtime.fibre import CallContext, CallContextFactory, Fibre, FibreNode
 from pybt2.runtime.types import (
-    AbstractContextKey,
     FibreNodeFunction,
     FibreNodeState,
     Key,
@@ -53,7 +52,7 @@ class CallContextForAnalysis(CallContext):
         self,
         props_type: Type[FibreNodeFunction[ResultT, StateT, UpdateT]],
         key: Optional[Key] = None,
-        additional_contexts: Optional[Mapping[AbstractContextKey, "FibreNode"]] = None,
+        additional_contexts: Optional[Mapping[Any, "FibreNode"]] = None,
     ) -> "FibreNode[FibreNodeFunction[ResultT, StateT, UpdateT], ResultT, StateT, UpdateT]":
         return self.ctx.get_child_fibre_node(
             props_type.get_props_type_for_analysis() if issubclass(props_type, SupportsAnalysis) else props_type,
@@ -62,13 +61,13 @@ class CallContextForAnalysis(CallContext):
         )
 
     @override
-    def evaluate_child(
+    def evaluate_child_raw(
         self,
         props: FibreNodeFunction[ResultT, StateT, UpdateT],
         key: Optional[Key] = None,
-        additional_contexts: Optional[Mapping[AbstractContextKey, "FibreNode"]] = None,
-    ) -> ResultT:
-        return self.ctx.evaluate_child(
+        additional_contexts: Optional[Mapping[Any, "FibreNode"]] = None,
+    ) -> FibreNodeState[FibreNodeFunction[ResultT, StateT, UpdateT], ResultT, StateT]:
+        return self.ctx.evaluate_child_raw(
             props.get_props_for_analysis() if isinstance(props, SupportsAnalysis) else props, key, additional_contexts
         )
 

--- a/pybt2/runtime/captures.py
+++ b/pybt2/runtime/captures.py
@@ -87,7 +87,7 @@ class UnorderedCaptureProvider(
     ) -> FibreNodeState[Self, tuple[ResultT, Mapping[FibreNode, T]], None]:
         capture_consumer_node = ctx.get_child_fibre_node(CaptureConsumer, CAPTURE_CONSUMER_KEY)
 
-        child_result = ctx.evaluate_child(
+        child_result = ctx.evaluate_child_raw(
             self.child, key=None, additional_contexts={self.capture_key: capture_consumer_node}
         )
         child_node = ctx.get_last_child()
@@ -95,8 +95,8 @@ class UnorderedCaptureProvider(
         capture_consumer_result = ctx.fibre.run(capture_consumer_node, CaptureConsumer[T]())
         return FibreNodeState(
             props=self,
-            result=(child_result, capture_consumer_result.result),
-            result_version=capture_consumer_result.result_version,
+            result=(child_result.result, capture_consumer_result.result),
+            result_version=child_result.result_version + capture_consumer_result.result_version,
             state=None,
             children=(child_node, capture_consumer_node),
         )

--- a/pybt2/runtime/contexts.py
+++ b/pybt2/runtime/contexts.py
@@ -4,13 +4,13 @@ from attr import frozen
 
 from pybt2.runtime.fibre import CallContext, FibreNode
 from pybt2.runtime.function_call import RuntimeCallableProps
-from pybt2.runtime.types import AbstractContextKey, ContextKey, FibreNodeFunction, ResultT
+from pybt2.runtime.types import ContextKey, FibreNodeFunction, ResultT
 
 T = TypeVar("T")
 
 
 def _context_value_key(context_key: ContextKey[T]) -> str:
-    return f"__ContextProvider.Value.{context_key.name}"
+    return f"__ContextProvider.Value.{context_key.id}"
 
 
 @frozen(weakref_slot=False)
@@ -30,7 +30,7 @@ class ContextProvider(RuntimeCallableProps[ResultT], Generic[T, ResultT]):
     def __call__(self, ctx: CallContext) -> ResultT:
         ctx.evaluate_child(ContextValue(self.value, key=_context_value_key(self.context_key)))
         context_value_node = ctx.get_last_child()
-        context_map: dict[AbstractContextKey, FibreNode] = {self.context_key: context_value_node}
+        context_map: dict[Any, FibreNode] = {self.context_key: context_value_node}
         return ctx.evaluate_child(self.child, additional_contexts=context_map)
 
 
@@ -40,7 +40,7 @@ class BatchContextProvider(RuntimeCallableProps[ResultT], Generic[ResultT]):
     child: FibreNodeFunction[ResultT, Any, Any]
 
     def __call__(self, ctx: CallContext) -> ResultT:
-        context_nodes: dict[AbstractContextKey, FibreNode] = {}
+        context_nodes: dict[Any, FibreNode] = {}
         for context_key, context_value in self.contexts.items():
             ctx.evaluate_child(ContextValue(context_value), key=_context_value_key(context_key))
             context_nodes[context_key] = ctx.get_last_child()

--- a/pybt2/runtime/hooks.py
+++ b/pybt2/runtime/hooks.py
@@ -7,6 +7,7 @@ from typing_extensions import Self, override
 from pybt2.runtime.fibre import CallContext
 from pybt2.runtime.function_call import RuntimeCallableProps
 from pybt2.runtime.types import (
+    NO_DEPENDENCIES,
     Dependencies,
     FibreNodeFunction,
     FibreNodeState,
@@ -25,6 +26,7 @@ UseStateResult = Tuple[T, Setter[T]]
 @frozen(weakref_slot=False)
 class UseStateHook(FibreNodeFunction[UseStateResult[T], None, Reducer[T]], Generic[T]):
     value: T = field(eq=False)
+    dependencies: Dependencies = NO_DEPENDENCIES
 
     @override
     def run(
@@ -38,10 +40,13 @@ class UseStateHook(FibreNodeFunction[UseStateResult[T], None, Reducer[T]], Gener
 
         if previous_state is not None:
             previous_value, previous_setter = previous_state.result
-            value = previous_value
             setter = previous_setter
-            for update in enqueued_updates:
-                value = cast(Callable[[T], T], update)(value) if callable(update) else cast(T, update)
+            if self.dependencies != previous_state.props.dependencies:
+                value = self.value
+            else:
+                value = previous_value
+                for update in enqueued_updates:
+                    value = cast(Callable[[T], T], update)(value) if callable(update) else cast(T, update)
             if value == previous_value:
                 return previous_state
         else:
@@ -57,8 +62,10 @@ class UseStateHook(FibreNodeFunction[UseStateResult[T], None, Reducer[T]], Gener
         return ctx.create_fibre_node_state(props=self, result=(value, setter), state=None)
 
 
-def use_state(ctx: CallContext, value: T, key: Optional[Key] = None) -> Tuple[T, Setter[T]]:
-    return ctx.evaluate_child(UseStateHook(value), key=key)
+def use_state(
+    ctx: CallContext, value: T, dependencies: Dependencies = NO_DEPENDENCIES, key: Optional[Key] = None
+) -> Tuple[T, Setter[T]]:
+    return ctx.evaluate_child(UseStateHook(value, dependencies=dependencies), key=key)
 
 
 UseResourceHookResourceFactory = Callable[[OnDispose], T]
@@ -176,7 +183,9 @@ class UseAsync(RuntimeCallableProps[AsyncResult[T]], Generic[T]):
     loop: Optional[asyncio.AbstractEventLoop] = field(eq=False, default=None, repr=False)
 
     def __call__(self, ctx: CallContext) -> AsyncResult[T]:
-        async_result, set_async_result = use_state(ctx, cast(AsyncResult[T], _ASYNC_RUNNING), key="result")
+        async_result, set_async_result = use_state(
+            ctx, cast(AsyncResult[T], _ASYNC_RUNNING), dependencies=self.dependencies, key="result"
+        )
 
         def construct_awaitable(on_dispose: OnDispose) -> asyncio.Task[T]:
             def on_done(completed_task: asyncio.Task[T]) -> None:
@@ -195,7 +204,6 @@ class UseAsync(RuntimeCallableProps[AsyncResult[T]], Generic[T]):
             return task
 
         use_resource(ctx, construct_awaitable, self.dependencies, key="task")
-
         return async_result
 
 

--- a/pybt2/runtime/services.py
+++ b/pybt2/runtime/services.py
@@ -7,7 +7,7 @@ from typing import (
     cast,
 )
 
-from attr import field, frozen
+from attr import frozen
 
 from pybt2.runtime.captures import use_capture
 from pybt2.runtime.fibre import CallContext
@@ -16,6 +16,7 @@ from pybt2.runtime.hooks import (
     AsyncResult,
     AsyncRunning,
     use_state,
+    use_version,
 )
 from pybt2.runtime.types import CaptureKey, Dependencies, Key, Setter
 
@@ -24,10 +25,6 @@ RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")
 
 _ASYNC_RUNNING = AsyncRunning()
-
-
-def capture_request(request: RequestT) -> RequestT:
-    return request
 
 
 @frozen(weakref_slot=False)
@@ -39,24 +36,28 @@ class ApiCall(Generic[RequestT, ResponseT]):
 @frozen(weakref_slot=False)
 class UseApiCall(RuntimeCallableProps[AsyncResult[ResponseT]], Generic[ApiT, RequestT, ResponseT]):
     api: Callable[[ApiT, RequestT], Awaitable[ResponseT]]
-    call: Callable[[Callable[[RequestT], Awaitable[ResponseT]]], Awaitable[ResponseT]] = field(eq=False)
+    request: RequestT
     dependencies: Dependencies
 
     def __call__(self, ctx: CallContext) -> AsyncResult[ResponseT]:
-        # FIXME: reset if dependencies change
-        async_result, set_async_result = use_state(ctx, cast(AsyncResult[ResponseT], _ASYNC_RUNNING))
+        dependencies_version = use_version(ctx, dependencies=self.dependencies, key="version")
+        async_result, set_async_result = use_state(
+            ctx, cast(AsyncResult[ResponseT], _ASYNC_RUNNING), key=dependencies_version
+        )
 
-        request = self.call(cast(Callable[[RequestT], Awaitable[ResponseT]], capture_request))
-        use_capture(ctx, CaptureKey(cast(str, self.api)), ApiCall(request, set_async_result))
+        use_capture(ctx, CaptureKey(self.api), ApiCall(self.request, set_async_result), key="capture")
         return async_result
 
 
 def use_api_call(
     ctx: CallContext,
-    *,
     api: Callable[[ApiT, RequestT], Awaitable[ResponseT]],
-    call: Callable[[Callable[[RequestT], Awaitable[ResponseT]]], Awaitable[ResponseT]],
-    dependencies: Dependencies,
+    request: RequestT,
+    *,
+    dependencies: Optional[Dependencies] = None,
     key: Optional[Key] = None,
 ) -> AsyncResult[ResponseT]:
-    return ctx.evaluate_child(UseApiCall(api, call, dependencies), key=key)
+    return ctx.evaluate_child(
+        UseApiCall(api=api, request=request, dependencies=dependencies if dependencies is not None else [request]),
+        key=key,
+    )

--- a/pybt2/runtime/services.py
+++ b/pybt2/runtime/services.py
@@ -1,0 +1,62 @@
+from typing import (
+    Awaitable,
+    Callable,
+    Generic,
+    Optional,
+    TypeVar,
+    cast,
+)
+
+from attr import field, frozen
+
+from pybt2.runtime.captures import use_capture
+from pybt2.runtime.fibre import CallContext
+from pybt2.runtime.function_call import RuntimeCallableProps
+from pybt2.runtime.hooks import (
+    AsyncResult,
+    AsyncRunning,
+    use_state,
+)
+from pybt2.runtime.types import CaptureKey, Dependencies, Key, Setter
+
+ApiT = TypeVar("ApiT")
+RequestT = TypeVar("RequestT")
+ResponseT = TypeVar("ResponseT")
+
+_ASYNC_RUNNING = AsyncRunning()
+
+
+def capture_request(request: RequestT) -> RequestT:
+    return request
+
+
+@frozen(weakref_slot=False)
+class ApiCall(Generic[RequestT, ResponseT]):
+    request: RequestT
+    set_async_result: Setter[AsyncResult[ResponseT]]
+
+
+@frozen(weakref_slot=False)
+class UseApiCall(RuntimeCallableProps[AsyncResult[ResponseT]], Generic[ApiT, RequestT, ResponseT]):
+    api: Callable[[ApiT, RequestT], Awaitable[ResponseT]]
+    call: Callable[[Callable[[RequestT], Awaitable[ResponseT]]], Awaitable[ResponseT]] = field(eq=False)
+    dependencies: Dependencies
+
+    def __call__(self, ctx: CallContext) -> AsyncResult[ResponseT]:
+        # FIXME: reset if dependencies change
+        async_result, set_async_result = use_state(ctx, cast(AsyncResult[ResponseT], _ASYNC_RUNNING))
+
+        request = self.call(cast(Callable[[RequestT], Awaitable[ResponseT]], capture_request))
+        use_capture(ctx, CaptureKey(cast(str, self.api)), ApiCall(request, set_async_result))
+        return async_result
+
+
+def use_api_call(
+    ctx: CallContext,
+    *,
+    api: Callable[[ApiT, RequestT], Awaitable[ResponseT]],
+    call: Callable[[Callable[[RequestT], Awaitable[ResponseT]]], Awaitable[ResponseT]],
+    dependencies: Dependencies,
+    key: Optional[Key] = None,
+) -> AsyncResult[ResponseT]:
+    return ctx.evaluate_child(UseApiCall(api, call, dependencies), key=key)

--- a/pybt2/runtime/types.py
+++ b/pybt2/runtime/types.py
@@ -33,6 +33,7 @@ Dependencies = Sequence[Any]
 
 NO_PREDECESSORS: Sequence["FibreNode"] = ()
 NO_CHILDREN: Sequence["FibreNode"] = NO_PREDECESSORS
+NO_DEPENDENCIES: Dependencies = ()
 _EMPTY_ITERATOR: Iterator[Any] = iter(())
 
 

--- a/pybt2/runtime/types.py
+++ b/pybt2/runtime/types.py
@@ -33,7 +33,6 @@ Dependencies = Sequence[Any]
 
 NO_PREDECESSORS: Sequence["FibreNode"] = ()
 NO_CHILDREN: Sequence["FibreNode"] = NO_PREDECESSORS
-NO_DEPENDENCIES: Dependencies = ()
 _EMPTY_ITERATOR: Iterator[Any] = iter(())
 
 
@@ -69,19 +68,24 @@ class FibreNodeState(Generic[PropsT, ResultT, StateT]):
     tree_structure_predecessors: Sequence["FibreNode"] = NO_PREDECESSORS
 
 
-class AbstractContextKey(metaclass=ABCMeta):
-    def __eq__(self, other: Any) -> bool:
-        return self is other
-
-    def __hash__(self) -> int:
-        return id(self)
-
-
 @frozen(eq=False, weakref_slot=False)
-class ContextKey(AbstractContextKey, Generic[T]):
-    name: str
+class UniqueString:
+    value: str
 
 
-@frozen(eq=False, weakref_slot=False)
-class CaptureKey(AbstractContextKey, Generic[T]):
-    name: str
+@frozen(weakref_slot=False)
+class ContextKey(Generic[T]):
+    id: Any
+
+    @classmethod
+    def create_unique(cls, name: str) -> "ContextKey[T]":
+        return cls(UniqueString(name))
+
+
+@frozen(weakref_slot=False)
+class CaptureKey(Generic[T]):
+    id: Any
+
+    @classmethod
+    def create_unique(cls, name: str) -> "CaptureKey[T]":
+        return cls(UniqueString(name))

--- a/tests/behaviour_tree/robot.py
+++ b/tests/behaviour_tree/robot.py
@@ -44,9 +44,9 @@ def next_robot_state(robot_state: RobotState, demands: RobotDemands) -> RobotSta
     )
 
 
-BatteryLevelContextKey = ContextKey[float]("BatteryLevelContext")
-PositionContextKey = ContextKey[float]("PositionContext")
-RobotVelocityDemandsCaptureKey = CaptureKey[float]("VelocityDemandsCapture")
+BatteryLevelContextKey = ContextKey[float].create_unique("BatteryLevelContext")
+PositionContextKey = ContextKey[float].create_unique("PositionContext")
+RobotVelocityDemandsCaptureKey = CaptureKey[float].create_unique("VelocityDemandsCapture")
 
 
 @frozen

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -11,7 +11,7 @@ from pybt2.runtime.types import ContextKey
 from .instrumentation import CallRecordingInstrumentation
 from .utils import EvaluateChild, ReturnArgument, run_in_fibre
 
-IntContextKey = ContextKey[int]("IntContextKey")
+IntContextKey = ContextKey[int].create_unique("IntContextKey")
 
 T = TypeVar("T")
 
@@ -194,9 +194,9 @@ def test_can_create_context_without_using_value(
     test_instrumentation.assert_evaluations_and_reset(("context-provider",), ("context-provider", "child"))
 
 
-def test_context_keys_use_identity_equality():
-    context_key_1 = ContextKey[int]("context")
-    context_key_2 = ContextKey[int]("context")
+def test_context_keys_use_identity_equality_when_created_via_unique():
+    context_key_1 = ContextKey[int].create_unique("context")
+    context_key_2 = ContextKey[int].create_unique("context")
 
     assert context_key_1 != context_key_2
     assert hash(context_key_1) != hash(context_key_2)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,77 @@
+from typing import Mapping
+
+import pytest
+from attr import frozen
+
+from pybt2.runtime.captures import UnorderedCaptureProvider
+from pybt2.runtime.fibre import CallContext, Fibre, FibreNode
+from pybt2.runtime.function_call import RuntimeCallableProps
+from pybt2.runtime.hooks import AsyncResult, AsyncRunning, AsyncSuccess
+from pybt2.runtime.services import ApiCall, use_api_call
+from pybt2.runtime.types import CaptureKey
+from tests.instrumentation import CallRecordingInstrumentation
+from tests.utils import run_in_fibre
+
+
+@frozen
+class ExampleService:
+    async def hello(self, name: str) -> str:
+        return f"Hello {name}"
+
+
+@pytest.mark.known_keys("capture-root", "use_api_call")
+@pytest.mark.asyncio()
+async def test_use_api_call(
+    fibre: Fibre, root_fibre_node: FibreNode, test_instrumentation: CallRecordingInstrumentation
+):
+    @frozen
+    class UseApiChild(RuntimeCallableProps[AsyncResult[str]]):
+        def __call__(self, ctx: CallContext) -> AsyncResult[str]:
+            return use_api_call(ctx, ExampleService.hello, "Wally", key="use_api_call")
+
+    @run_in_fibre(fibre, root_fibre_node)
+    def execute_1(ctx: CallContext) -> tuple[AsyncResult[str], Mapping[FibreNode, str]]:
+        return ctx.evaluate_child(
+            UnorderedCaptureProvider[AsyncResult[str], str](
+                CaptureKey(ExampleService.hello), UseApiChild(key="use-api-child"), key="capture-root"
+            )
+        )
+
+    use_api_node = root_fibre_node.get_fibre_node(("capture-root", "use-api-child", "use_api_call"))
+    capture_leaf_node = use_api_node.get_fibre_node(("capture",))
+    use_state_node = use_api_node.get_fibre_node((1,))
+
+    test_instrumentation.assert_evaluations_and_reset(
+        ("capture-root",),
+        ("capture-root", "use_api_call"),
+        ("capture-root",),
+    )
+
+    fibre_node_state = use_state_node.get_fibre_node_state()
+    assert fibre_node_state is not None
+    _, set_async_result = fibre_node_state.result
+    assert execute_1.result == (
+        AsyncRunning(),
+        {capture_leaf_node: ApiCall(request="Wally", set_async_result=set_async_result)},
+    )
+
+    set_async_result(AsyncSuccess("Hello Wally"))
+    assert use_state_node.is_out_of_date()
+
+    fibre.drain_work_queue()
+
+    @run_in_fibre(fibre, root_fibre_node)
+    def execute_2(ctx: CallContext) -> tuple[AsyncResult[str], Mapping[FibreNode, str]]:
+        return ctx.evaluate_child(
+            UnorderedCaptureProvider[AsyncResult[str], str](
+                CaptureKey(ExampleService.hello), UseApiChild(key="use-api-child"), key="capture-root"
+            )
+        )
+
+    fibre_node_state = use_state_node.get_fibre_node_state()
+    assert fibre_node_state is not None
+    _, set_async_result = fibre_node_state.result
+    assert execute_2.result == (
+        AsyncSuccess("Hello Wally"),
+        {capture_leaf_node: ApiCall(request="Wally", set_async_result=set_async_result)},
+    )


### PR DESCRIPTION
### Summary :memo:
`use_api_call` makes it easy to "call" an API from a Behaviour Tree node. In actuality, the request is captured, and a separate BT node can decide which requests to fulfil.

